### PR TITLE
feat: update tenant creation response and onboarding logic

### DIFF
--- a/handlers/dto.go
+++ b/handlers/dto.go
@@ -70,7 +70,6 @@ type TenantSummary struct {
 
 type TenantCreateResponse struct {
 	Tenant       TenantSummary `json:"tenant"`
-	AdminUserID  string        `json:"admin_user_id"`
 	TempPassword string        `json:"temp_password"`
 	Status       string        `json:"status"`
 }

--- a/handlers/tenant_create_handler.go
+++ b/handlers/tenant_create_handler.go
@@ -79,12 +79,11 @@ func (h *TenantCreateHandler) Create(c *gin.Context) {
 			Domain: result.Domain,
 			Slug:   result.Slug,
 		},
-		AdminUserID:  result.AdminUserID,
 		TempPassword: result.TempPassword,
 		Status:       string(result.Status),
 	}
 
-	status := http.StatusAccepted
+	status := http.StatusCreated
 	if cached {
 		status = http.StatusOK
 	}

--- a/services/tenant.go
+++ b/services/tenant.go
@@ -136,8 +136,6 @@ func (s *tenantService) OnboardTenantAsync(ctx context.Context, actor UserRead, 
 	err = s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		tenantRepo := repositories.NewGormTenantRepo(tx)
 		userRepo := repositories.NewGormUserRepo(tx)
-		outboxRepo := repositories.NewGormOutboxRepo(tx)
-		bus := eventbus.NewOutboxBus(outboxRepo)
 
 		tenantID := uuid.NewString()
 		slugCopy := slug
@@ -145,7 +143,7 @@ func (s *tenantService) OnboardTenantAsync(ctx context.Context, actor UserRead, 
 			ID:        tenantID,
 			Name:      normalizedName,
 			Slug:      &slugCopy,
-			Status:    models.TenantPending,
+			Status:    models.TenantActive,
 			CreatedBy: &actor.ID,
 		}
 		if domainPtr != nil {
@@ -182,20 +180,8 @@ func (s *tenantService) OnboardTenantAsync(ctx context.Context, actor UserRead, 
 			return err
 		}
 
-		eventPayload := eventbus.TenantCreatedV1{
-			V:             1,
-			TenantID:      tenantID,
-			Name:          tenant.Name,
-			Plan:          string(defaultPlanValue(planPtr)),
-			CreatorUserID: actor.ID,
-			CreatedAt:     time.Now().UTC().Format(time.RFC3339),
-		}
-		if domainPtr != nil {
-			eventPayload.Domain = *domainPtr
-		}
-		if err := bus.PublishTenantCreated(ctx, eventPayload); err != nil {
-			return err
-		}
+		// Skipping event publishing - tenant is immediately active
+		// No async onboarding queue processing needed
 
 		result = TenantOnboardAsyncResult{
 			TenantID:     tenantID,
@@ -234,7 +220,6 @@ func (s *tenantService) OnboardTenantAsync(ctx context.Context, actor UserRead, 
 			"id":   result.TenantID,
 			"name": result.Name,
 		},
-		"admin_user_id": result.AdminUserID,
 		"temp_password": result.TempPassword,
 		"status":        string(result.Status),
 	}


### PR DESCRIPTION
This pull request simplifies the tenant onboarding process by making tenants immediately active upon creation and removing the asynchronous onboarding workflow. It also updates the API response and status codes to reflect these changes.

**Tenant onboarding workflow changes:**

* Tenants are now created with `Status: Active` instead of `Status: Pending`, making them immediately usable after creation.
* The asynchronous event publishing and outbox bus logic for tenant creation has been removed, as onboarding no longer requires background processing. [[1]](diffhunk://#diff-bb032b46947186ce32cbf4a36412d83aefadc15421710c4ea87f34bb660226b0L139-R146) [[2]](diffhunk://#diff-bb032b46947186ce32cbf4a36412d83aefadc15421710c4ea87f34bb660226b0L185-R184)

**API and response updates:**

* The `AdminUserID` field has been removed from the `TenantCreateResponse` struct and related API responses, as it is no longer relevant to the onboarding flow. [[1]](diffhunk://#diff-595413d43fbd4edce418d65b38c2670d61bab5235f957e0aa7a89d663e89e128L73) [[2]](diffhunk://#diff-bb032b46947186ce32cbf4a36412d83aefadc15421710c4ea87f34bb660226b0L237)
* The HTTP status code returned on successful tenant creation is now `201 Created` instead of `202 Accepted`.